### PR TITLE
Introduce ModelPool for dynamic multi-model loading

### DIFF
--- a/src/inference/llm.rs
+++ b/src/inference/llm.rs
@@ -18,6 +18,21 @@ pub enum LlmBackend {
     MiniCpmSala,
 }
 
+impl LlmBackend {
+    pub fn from_model_type(model_type: &str) -> Option<Self> {
+        match model_type {
+            "qwen2" => Some(LlmBackend::Qwen2),
+            "qwen3" | "qwen" => Some(LlmBackend::Qwen3),
+            "mistral" => Some(LlmBackend::Mistral),
+            "glm4" | "chatglm" => Some(LlmBackend::Glm4),
+            "mixtral" => Some(LlmBackend::Mixtral),
+            "minicpm" | "minicpm4" => Some(LlmBackend::MiniCpmSala),
+            _ => None,
+        }
+    }
+}
+
+
 /// A loaded LLM model with its tokenizer.
 pub struct LlmEngine {
     backend: LlmBackend,

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc;
 pub enum InferenceRequest {
     /// Chat completion (LLM or VLM)
     Chat {
+        model_id: String,
         messages: Vec<(String, String)>,
         max_tokens: usize,
         temperature: f32,
@@ -18,18 +19,21 @@ pub enum InferenceRequest {
     },
     /// Speech-to-text (ASR)
     Transcribe {
+        model_id: String,
         audio_samples: Vec<f32>,
         sample_rate: u32,
         response_tx: tokio::sync::oneshot::Sender<Result<String, String>>,
     },
     /// Text-to-speech (TTS)
     Synthesize {
+        model_id: String,
         text: String,
         reference_audio: Option<String>,
         response_tx: tokio::sync::oneshot::Sender<Result<Vec<f32>, String>>,
     },
     /// Image generation
     GenerateImage {
+        model_id: String,
         prompt: String,
         width: u32,
         height: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod config;
-pub mod models;
-pub mod download;
+pub mod image_gen;
+pub mod orchestration;
+
+use std::path::Path;
 pub mod inference;
 pub mod api;
 pub mod gui;

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::path::PathBuf;
+
+use crate::inference::llm::LlmEngine;
+use crate::inference::asr::AsrEngine;
+use crate::inference::tts::TtsEngine;
+use crate::inference::image_gen::ImageGenEngine;
+use crate::config::AppConfig;
+
+/// Types of models supported by the orchestrator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelType {
+    LLM,
+    VLM,
+    ASR,
+    TTS,
+    ImageGen,
+}
+
+/// Trait for any model managed by the pool.
+pub trait ManagedModel: Send + Sync {
+    fn id(&self) -> &str;
+    fn model_type(&self) -> ModelType;
+    fn as_any(&self) -> &dyn std::any::Any;
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+}
+
+// Wrappers to implement ManagedModel for specific engines
+// We need wrappers because the engines themselves might not implement Send+Sync or we want to add metadata.
+// For the GSoC prototype, we assume the MLX engines are Send. (They are usually valid to send across threads).
+
+pub struct ManagedLlm(pub LlmEngine);
+impl ManagedModel for ManagedLlm {
+    fn id(&self) -> &str { self.0.model_id() }
+    fn model_type(&self) -> ModelType { ModelType::LLM }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+}
+
+pub struct ManagedAsr(pub AsrEngine);
+impl ManagedModel for ManagedAsr {
+    fn id(&self) -> &str { self.0.model_id() }
+    fn model_type(&self) -> ModelType { ModelType::ASR }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+}
+
+pub struct ManagedTts(pub TtsEngine);
+impl ManagedModel for ManagedTts {
+    fn id(&self) -> &str { self.0.model_id() }
+    fn model_type(&self) -> ModelType { ModelType::TTS }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+}
+
+/// Manages a pool of loaded models.
+pub struct ModelPool {
+    models: HashMap<String, Box<dyn ManagedModel>>,
+    config: Arc<Mutex<AppConfig>>,
+}
+
+impl ModelPool {
+    pub fn new(config: AppConfig) -> Self {
+        Self {
+            models: HashMap::new(),
+            config: Arc::new(Mutex::new(config)),
+        }
+    }
+
+    pub fn get_model(&mut self, model_id: &str) -> Option<&mut dyn ManagedModel> {
+        self.models.get_mut(model_id).map(|b| b.as_mut())
+    }
+    
+    pub fn is_loaded(&self, model_id: &str) -> bool {
+        self.models.contains_key(model_id)
+    }
+
+    pub fn list_loaded(&self) -> Vec<String> {
+        self.models.keys().cloned().collect()
+    }
+    
+    pub fn load_model(&mut self, model_id: &str) -> Result<(), String> {
+        if self.models.contains_key(model_id) {
+            return Ok(());
+        }
+
+        let config = self.config.lock().unwrap();
+        let entry = config.models.iter().find(|m| m.id == model_id)
+            .ok_or_else(|| format!("Model '{}' not found in configuration", model_id))?
+            .clone();
+        drop(config); // Unlock early
+        
+        let path = PathBuf::from(&entry.path);
+        
+        // Attempt to detect LLM backend
+        if let Some(backend) = crate::inference::llm::LlmBackend::from_model_type(&entry.model_type) {
+            let engine = LlmEngine::load(&path, backend, model_id)?;
+            self.models.insert(model_id.to_string(), Box::new(ManagedLlm(engine)));
+            return Ok(());
+        }
+        
+        // Other types
+        match entry.model_type.as_str() {
+            "funasr" | "paraformer" => {
+                 let engine = AsrEngine::load(&path, model_id)?;
+                 self.models.insert(model_id.to_string(), Box::new(ManagedAsr(engine)));
+                 Ok(())
+            },
+            "gpt-sovits" => {
+                 let engine = TtsEngine::load(&path, model_id)?;
+                 self.models.insert(model_id.to_string(), Box::new(ManagedTts(engine)));
+                 Ok(())
+            },
+            _ => Err(format!("Unsupported model type: {} for model {}", entry.model_type, model_id)),
+        }
+    }


### PR DESCRIPTION
Before anything this is just a prototype or proposal for my solution and this is phase 1 and i will be implementing more in this 
repository  ay suggestions for me is much appreciated thanks for the time


Description
-----------

This PR introduces the foundational architecture for the **Edge Model Orchestrator** GSoC proposal. It transforms mofa-local-llm from a single-model static server into a dynamic multi-model system capable of loading LLM, ASR, and TTS models on demand.

The goal is to enable complex local AI pipelines (e.g., Voice -> LLM -> TTS) where multiple models must coexist and interact efficiently within the same process space, leveraging Apple Silicon's unified memory.

Key Changes
-----------

### 1\. New ModelPool Architecture

*   Added src/orchestration/mod.rs to manage the lifecycle of multiple models.
    
*   Implemented ManagedModel trait to unify different model types (LlmEngine, AsrEngine, TtsEngine).
    
*   Implemented load\_model with logic to inspect config.json and instantiate the correct backend (Qwen, Mistral, Paraformer, etc.).
    

### 2\. Dynamic Model Loading

*   Refactored src/bin/server.rs to initialize with an **empty** ModelPool instead of loading a single model at startup.
    
*   Implemented **Load-on-Demand**: The server intercepts incoming inference requests, checks if the target model is loaded, and loads it transparently if missing.
    

### 3\. API Enhancements

*   **Chat (/v1/chat/completions)**: Now respects the model field in the request body to route to the correct loaded model.
    
*   **ASR (/v1/audio/transcriptions)**: Added support for ?model= query parameter to select specific ASR models.
    

Future Work (GSoC Roadmap kind of still in progress)
--------------------------

*    **Memory Management**: Implement LRU eviction to unload unused models when RAM is full.
    
*    **Zero-Copy Pipeline**: Implement direct mlx\_rs::Array passing between models to avoid serialization overhead.
    
*    **Pipeline API**: Add /v1/pipeline endpoint for defining multi-step workflows.


resolves issue #5 