### PR TITLE
fix: map "qwen2" model type to correct Qwen2 backend in GUI

### DIFF
--- a/src/gui/app.rs
+++ b/src/gui/app.rs
@@ -552,7 +552,8 @@ impl eframe::App for MofaApp {
 
 fn detect_backend(model_type: &str) -> Option<LlmBackend> {
     match model_type {
-        "qwen2" | "qwen3" | "qwen" => Some(LlmBackend::Qwen3),
+        "qwen2" => Some(LlmBackend::Qwen2),
+        "qwen3" | "qwen" => Some(LlmBackend::Qwen3),
         "mistral" => Some(LlmBackend::Mistral),
         "glm4" | "chatglm" => Some(LlmBackend::Glm4),
         "mixtral" => Some(LlmBackend::Mixtral),


### PR DESCRIPTION
## Summary

This PR fixes an incorrect backend mapping in `detect_backend()` inside `src/gui/app.rs`. Previously, the GUI mapped both `"qwen2"` and `"qwen3"` to `LlmBackend::Qwen3`, which caused Qwen2 models to be loaded using the wrong backend.

## Issue

Qwen2 requires its dedicated loader (`LlmBackend::Qwen2`) to correctly handle architecture-specific details such as 4-bit quantization and attention biases. Loading Qwen2 models with the Qwen3 backend resulted in incompatible weight mapping and garbled inference output.

## Fix

* Map `"qwen2"` → `LlmBackend::Qwen2`
* Keep `"qwen3" | "qwen"` → `LlmBackend::Qwen3`

This brings the GUI behavior in sync with `src/bin/server.rs`, which already handled `"qwen2"` correctly.

## Notes

* Only `mofa-gui` was affected
* No new dependencies added
* Verified with `cargo build --release`

Closes #2
