### PR TITLE
feat: add library API for external use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.82.0"
 description = "Local ML inference server and GUI for Apple Silicon, powered by OminiX-MLX"
+# Note: This crate is designed to be used as a standalone library.
+# When copied to a separate repository, ensure workspace configuration is set up appropriately.
 
 [[bin]]
 name = "mofa-server"

--- a/library_api.md
+++ b/library_api.md
@@ -1,0 +1,268 @@
+# Library API Documentation
+
+This document describes the new library API added to mofa-local-llm for use as a dependency in other projects (e.g., MoFA).
+
+## Overview
+
+The library API provides a clean, thread-safe interface for loading and using LLM models without requiring the HTTP server or GUI components.
+
+## Key Components
+
+### `LocalLLMClient`
+
+The main entry point for using mofa-local-llm as a library.
+
+**Location**: `src/lib_api.rs`
+
+**Exported from**: `mofa_local_llm::LocalLLMClient`
+
+## Usage Example
+
+```rust
+use mofa_local_llm::LocalLLMClient;
+
+// Create client with default model directory (~/.mofa/models/)
+let client = LocalLLMClient::new(None)?;
+
+// Or specify a custom models directory
+let client = LocalLLMClient::new(Some(PathBuf::from("/path/to/models")))?;
+
+// List available models
+let models = client.list_models();
+println!("Available models: {:?}", models);
+
+// Load a model by ID
+client.load_model("qwen2.5-0.5b-instruct")?;
+
+// Or load from a direct path
+let model_id = client.load_model_from_path("/path/to/model", None)?;
+
+// Run inference
+let result = client.chat(
+    "qwen2.5-0.5b-instruct",
+    &[
+        ("system".to_string(), "You are a helpful assistant.".to_string()),
+        ("user".to_string(), "Hello!".to_string()),
+    ],
+    128,  // max_tokens
+    0.7,  // temperature
+)?;
+
+println!("Response: {}", result.text);
+println!("Tokens: {}/{}", result.completion_tokens, result.prompt_tokens);
+println!("Speed: {:.1} tok/s", result.decode_tps);
+
+// Unload model when done (optional, frees memory)
+client.unload_model("qwen2.5-0.5b-instruct");
+```
+
+## API Reference
+
+### `LocalLLMClient::new(models_dir: Option<PathBuf>) -> Result<Self, String>`
+
+Creates a new `LocalLLMClient` instance.
+
+- `models_dir`: Optional path to models directory. If `None`, uses default `~/.mofa/models/`
+- Returns: `Ok(LocalLLMClient)` on success, or `Err(String)` on failure
+
+### `list_models() -> Vec<String>`
+
+Returns a list of all available model IDs (both loaded and discovered).
+
+### `is_model_loaded(model_id: &str) -> bool`
+
+Checks if a model is currently loaded in memory.
+
+### `get_model_info(model_id: &str) -> Option<ModelEntry>`
+
+Gets model entry information for a given model ID.
+
+### `load_model(model_id: &str) -> Result<(), String>`
+
+Loads a model by its ID. The model must be present in the discovered models list.
+
+- Returns: `Ok(())` on success, or `Err(String)` if the model cannot be found or loaded
+
+### `load_model_from_path(model_path: impl AsRef<Path>, model_id: Option<&str>) -> Result<String, String>`
+
+Loads a model from a direct path. Useful when you have a model path that hasn't been discovered yet.
+
+- `model_path`: Path to the model directory
+- `model_id`: Optional model ID. If `None`, uses the directory name
+- Returns: The model ID on success
+
+### `unload_model(model_id: &str)`
+
+Unloads a model from memory, freeing resources.
+
+### `chat(model_id: &str, messages: &[(String, String)], max_tokens: usize, temperature: f32) -> Result<ChatResult, String>`
+
+Runs chat completion inference.
+
+- `model_id`: The ID of the loaded model
+- `messages`: Vector of (role, content) tuples. Roles should be "system", "user", or "assistant"
+- `max_tokens`: Maximum number of tokens to generate
+- `temperature`: Sampling temperature (0.0 to 1.0+)
+- Returns: `Ok(ChatResult)` on success
+
+### `scan_models_dir()`
+
+Scans the models directory for new models and updates the internal registry.
+
+### `models_dir() -> PathBuf`
+
+Gets the current models directory path.
+
+### `config() -> AppConfig`
+
+Gets a copy of the current configuration.
+
+## Thread Safety
+
+`LocalLLMClient` is thread-safe and can be shared across threads using `Arc`:
+
+```rust
+use std::sync::Arc;
+
+let client = Arc::new(LocalLLMClient::new(None)?);
+
+// Can be cloned and shared
+let client_clone = Arc::clone(&client);
+```
+
+## Concurrency and Thread Safety
+
+**Important Concurrency Notes:**
+
+- **Multiple models**: Different models can run inference concurrently
+- **Per-model concurrency**: Only one inference can run per model at a time
+  - Concurrent requests to the same model will block sequentially
+  - This is due to MLX inference requiring mutable access to model state (KV cache, etc.)
+  - The write lock ensures thread safety but serializes requests per model
+
+**For async contexts**, use `tokio::task::spawn_blocking()`:
+
+```rust
+use std::sync::Arc;
+use tokio::task;
+
+let client = Arc::new(LocalLLMClient::new(None)?);
+let client_clone = Arc::clone(&client);
+
+// In async function
+let result = task::spawn_blocking(move || {
+    client_clone.chat("model-id", &messages, 128, 0.7)
+}).await??;
+```
+
+**Example: Concurrent requests to different models:**
+
+```rust
+use std::sync::Arc;
+use tokio::task;
+
+let client = Arc::new(LocalLLMClient::new(None)?);
+
+// These will run concurrently (different models)
+let handle1 = task::spawn_blocking({
+    let c = Arc::clone(&client);
+    move || c.chat("model-1", &messages1, 128, 0.7)
+});
+
+let handle2 = task::spawn_blocking({
+    let c = Arc::clone(&client);
+    move || c.chat("model-2", &messages2, 128, 0.7)
+});
+
+let (r1, r2) = tokio::join!(handle1, handle2);
+```
+
+**Example: Sequential requests to same model:**
+
+```rust
+use std::sync::Arc;
+use tokio::task;
+
+let client = Arc::new(LocalLLMClient::new(None)?);
+
+// These will run sequentially (same model)
+let r1 = task::spawn_blocking({
+    let c = Arc::clone(&client);
+    move || c.chat("model-1", &messages1, 128, 0.7)
+}).await??;
+
+let r2 = task::spawn_blocking({
+    let c = Arc::clone(&client);
+    move || c.chat("model-1", &messages2, 128, 0.7)  // Same model
+}).await??;
+```
+
+## Async Usage Example
+
+Here's a complete example showing how to use `LocalLLMClient` in an async context:
+
+```rust
+use std::sync::Arc;
+use mofa_local_llm::LocalLLMClient;
+use tokio::task;
+
+async fn run_inference() -> Result<(), Box<dyn std::error::Error>> {
+    // Create client
+    let client = Arc::new(LocalLLMClient::new(None)?);
+    
+    // Load model (can be done in blocking context or async with spawn_blocking)
+    let client_clone = Arc::clone(&client);
+    task::spawn_blocking(move || {
+        client_clone.load_model("qwen2.5-0.5b-instruct")
+    }).await??;
+    
+    // Run inference
+    let messages = vec![
+        ("system".to_string(), "You are helpful.".to_string()),
+        ("user".to_string(), "Hello!".to_string()),
+    ];
+    
+    let client_clone = Arc::clone(&client);
+    let result = task::spawn_blocking(move || {
+        client_clone.chat("qwen2.5-0.5b-instruct", &messages, 128, 0.7)
+    }).await??;
+    
+    println!("Response: {}", result.text);
+    Ok(())
+}
+```
+
+## Supported Model Types
+
+The library automatically detects the backend from the model's `config.json`:
+
+- `qwen2` → Qwen2 backend
+- `qwen3` or `qwen` → Qwen3 backend
+- `mistral` → Mistral backend
+- `glm4` or `chatglm` → GLM-4 backend
+- `mixtral` → Mixtral backend
+- `minicpm` or `minicpm4` → MiniCPM-SALA backend
+
+## Error Handling
+
+All methods return `Result<T, String>` where the error string provides a descriptive message about what went wrong.
+
+Common errors:
+- Model not found: "Model 'X' not found. Use list_models() to see available models."
+- Model not loaded: "Model 'X' is not loaded. Call load_model() first."
+- Unknown model type: "Unknown model type: X"
+- Load failure: "Failed to load model 'X': <details>"
+
+## Integration with MoFA
+
+This library API is designed to be used by MoFA's `LocalLLMProvider` implementation. The provider will:
+
+1. Create a `LocalLLMClient` instance
+2. Load models on demand
+3. Convert MoFA's message types to `(String, String)` tuples
+4. Convert `ChatResult` back to MoFA's response types
+5. Handle errors appropriately
+
+## Backward Compatibility
+
+The existing HTTP server (`mofa-server`) and GUI (`mofa-gui`) binaries continue to work unchanged. The library API is additive and does not break existing functionality.

--- a/library_api.md
+++ b/library_api.md
@@ -20,6 +20,7 @@ The main entry point for using mofa-local-llm as a library.
 
 ```rust
 use mofa_local_llm::LocalLLMClient;
+use std::path::PathBuf;
 
 // Create client with default model directory (~/.mofa/models/)
 let client = LocalLLMClient::new(None)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,11 @@ pub mod download;
 pub mod inference;
 pub mod api;
 pub mod gui;
+
+// Library API for external use
+pub mod lib_api;
+pub use lib_api::LocalLLMClient;
+
+// Re-export commonly used types
+pub use inference::ChatResult;
+pub use config::ModelEntry;

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -277,7 +277,8 @@ mod tests {
     fn test_list_models() {
         let client = LocalLLMClient::new(None).unwrap();
         let models = client.list_models();
-        assert!(models.len() >= 0);
+        // Verify all model IDs are non-empty strings
+        assert!(models.iter().all(|id| !id.is_empty()));
     }
 
     #[test]

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -1,0 +1,54 @@
+//! Library API for mofa-local-llm
+//!
+//! This module provides a clean, thread-safe API for using mofa-local-llm
+//! as a library, without requiring the HTTP server or GUI components.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use crate::config::{AppConfig, ModelEntry};
+use crate::inference::llm::{LlmBackend, LlmEngine};
+use crate::inference::ChatResult;
+
+/// Detects the LLM backend from a model type string.
+fn detect_backend(model_type: &str) -> Option<LlmBackend> {
+    match model_type {
+        "qwen2" => Some(LlmBackend::Qwen2),
+        "qwen3" | "qwen" => Some(LlmBackend::Qwen3),
+        "mistral" => Some(LlmBackend::Mistral),
+        "glm4" | "chatglm" => Some(LlmBackend::Glm4),
+        "mixtral" => Some(LlmBackend::Mixtral),
+        "minicpm" | "minicpm4" => Some(LlmBackend::MiniCpmSala),
+        _ => None,
+    }
+}
+
+/// Thread-safe client for managing and using local LLM models.
+///
+/// This client provides a library API for loading and using LLM models
+/// without requiring the HTTP server. It manages model lifecycle and
+/// provides thread-safe access to multiple models.
+pub struct LocalLLMClient {
+    config: Arc<RwLock<AppConfig>>,
+    engines: Arc<RwLock<HashMap<String, Arc<RwLock<LlmEngine>>>>>,
+}
+
+impl LocalLLMClient {
+    /// Create a new `LocalLLMClient` instance.
+    pub fn new(models_dir: Option<PathBuf>) -> Result<Self, String> {
+        let models_dir_str = models_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string());
+
+        let mut config = AppConfig::load(models_dir_str.as_deref());
+        config.scan_models_dir();
+        
+        let _ = config.save();
+
+        Ok(Self {
+            config: Arc::new(RwLock::new(config)),
+            engines: Arc::new(RwLock::new(HashMap::new())),
+        })
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -51,7 +51,7 @@ impl LocalLLMClient {
             engines: Arc::new(RwLock::new(HashMap::new())),
         })
     }
-}
+
     pub fn models_dir(&self) -> PathBuf {
         let config = self.config.read().unwrap();
         PathBuf::from(&config.models_dir)
@@ -66,7 +66,7 @@ impl LocalLLMClient {
         let engines = self.engines.read().unwrap();
         engines.contains_key(model_id)
     }
-}
+
     pub fn get_model_info(&self, model_id: &str) -> Option<ModelEntry> {
         let config = self.config.read().unwrap();
         config
@@ -110,7 +110,7 @@ impl LocalLLMClient {
 
         Ok(())
     }
-}
+
     pub fn chat(
         &self,
         model_id: &str,
@@ -128,7 +128,7 @@ impl LocalLLMClient {
         let mut engine = engine_arc.write().unwrap();
         engine.chat(messages, max_tokens, temperature)
     }
-}
+
     pub fn chat_with_auto_load(
         &self,
         model_id: &str,
@@ -233,6 +233,7 @@ impl LocalLLMClient {
         Ok(model_id)
     }
 }
+
 impl Clone for LocalLLMClient {
     fn clone(&self) -> Self {
         Self {

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -241,3 +241,26 @@ impl Clone for LocalLLMClient {
         }
     }
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_with_default_dir() {
+        let client = LocalLLMClient::new(None);
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_list_models() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let models = client.list_models();
+        assert!(models.len() >= 0);
+    }
+
+    #[test]
+    fn test_is_model_loaded_false() {
+        let client = LocalLLMClient::new(None).unwrap();
+        assert!(!client.is_model_loaded("nonexistent-model"));
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -67,3 +67,47 @@ impl LocalLLMClient {
         engines.contains_key(model_id)
     }
 }
+    pub fn get_model_info(&self, model_id: &str) -> Option<ModelEntry> {
+        let config = self.config.read().unwrap();
+        config
+            .models
+            .iter()
+            .find(|m| m.id == model_id)
+            .cloned()
+    }
+
+    pub fn load_model(&self, model_id: &str) -> Result<(), String> {
+        {
+            let engines = self.engines.read().unwrap();
+            if engines.contains_key(model_id) {
+                return Ok(());
+            }
+        }
+
+        let model_entry = {
+            let config = self.config.read().unwrap();
+            config
+                .models
+                .iter()
+                .find(|m| m.id == model_id)
+                .cloned()
+                .ok_or_else(|| format!("Model '{}' not found. Use list_models() to see available models.", model_id))?
+        };
+
+        let backend = detect_backend(&model_entry.model_type)
+            .ok_or_else(|| format!("Unknown model type: {}", model_entry.model_type))?;
+
+        let model_path = Path::new(&model_entry.path);
+        if !model_path.exists() {
+            return Err(format!("Model path does not exist: {}", model_entry.path));
+        }
+
+        let engine = LlmEngine::load(model_path, backend, model_id)
+            .map_err(|e| format!("Failed to load model '{}': {}", model_id, e))?;
+
+        let mut engines = self.engines.write().unwrap();
+        engines.insert(model_id.to_string(), Arc::new(RwLock::new(engine)));
+
+        Ok(())
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -44,7 +44,8 @@ impl LocalLLMClient {
         let mut config = AppConfig::load(models_dir_str.as_deref());
         config.scan_models_dir();
         
-        let _ = config.save();
+        config.save()
+            .map_err(|e| format!("Failed to save config: {}", e))?;
 
         Ok(Self {
             config: Arc::new(RwLock::new(config)),
@@ -77,6 +78,7 @@ impl LocalLLMClient {
     }
 
     pub fn load_model(&self, model_id: &str) -> Result<(), String> {
+        // Check if already loaded (quick read check first)
         {
             let engines = self.engines.read().unwrap();
             if engines.contains_key(model_id) {
@@ -84,6 +86,7 @@ impl LocalLLMClient {
             }
         }
 
+        // Get model entry info (outside the write lock to minimize lock time)
         let model_entry = {
             let config = self.config.read().unwrap();
             config
@@ -102,10 +105,17 @@ impl LocalLLMClient {
             return Err(format!("Model path does not exist: {}", model_entry.path));
         }
 
+        // Double-check and insert with write lock to prevent race condition
+        let mut engines = self.engines.write().unwrap();
+        // Check again under write lock to prevent duplicate loads
+        if engines.contains_key(model_id) {
+            return Ok(());
+        }
+
+        // Load the model (expensive operation, but now protected by write lock)
         let engine = LlmEngine::load(model_path, backend, model_id)
             .map_err(|e| format!("Failed to load model '{}': {}", model_id, e))?;
 
-        let mut engines = self.engines.write().unwrap();
         engines.insert(model_id.to_string(), Arc::new(RwLock::new(engine)));
 
         Ok(())
@@ -147,10 +157,12 @@ impl LocalLLMClient {
         engines.remove(model_id);
     }
 
-    pub fn scan_models_dir(&self) {
+    pub fn scan_models_dir(&self) -> Result<(), String> {
         let mut config = self.config.write().unwrap();
         config.scan_models_dir();
-        let _ = config.save();
+        config.save()
+            .map_err(|e| format!("Failed to save config: {}", e))?;
+        Ok(())
     }
 
     pub fn config(&self) -> AppConfig {
@@ -383,7 +395,8 @@ mod tests {
     fn test_scan_models_dir() {
         let client = LocalLLMClient::new(None).unwrap();
         // Should not panic
-        client.scan_models_dir();
+        let result = client.scan_models_dir();
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -129,3 +129,107 @@ impl LocalLLMClient {
         engine.chat(messages, max_tokens, temperature)
     }
 }
+    pub fn chat_with_auto_load(
+        &self,
+        model_id: &str,
+        messages: &[(String, String)],
+        max_tokens: usize,
+        temperature: f32,
+    ) -> Result<ChatResult, String> {
+        if !self.is_model_loaded(model_id) {
+            self.load_model(model_id)?;
+        }
+        self.chat(model_id, messages, max_tokens, temperature)
+    }
+
+    pub fn unload_model(&self, model_id: &str) {
+        let mut engines = self.engines.write().unwrap();
+        engines.remove(model_id);
+    }
+
+    pub fn scan_models_dir(&self) {
+        let mut config = self.config.write().unwrap();
+        config.scan_models_dir();
+        let _ = config.save();
+    }
+
+    pub fn config(&self) -> AppConfig {
+        self.config.read().unwrap().clone()
+    }
+
+    pub fn loaded_models(&self) -> Vec<String> {
+        let engines = self.engines.read().unwrap();
+        engines.keys().cloned().collect()
+    }
+
+    pub fn default_model(&self) -> Option<String> {
+        let models = self.list_models();
+        models.first().cloned()
+    }
+
+    pub fn is_model_available(&self, model_id: &str) -> bool {
+        let config = self.config.read().unwrap();
+        config
+            .models
+            .iter()
+            .any(|m| m.id == model_id && Path::new(&m.path).exists())
+    }
+
+    pub fn get_model_backend(&self, model_id: &str) -> Option<LlmBackend> {
+        let model_entry = self.get_model_info(model_id)?;
+        detect_backend(&model_entry.model_type)
+    }
+
+    pub fn load_model_from_path(
+        &self,
+        model_path: impl AsRef<Path>,
+        model_id: Option<&str>,
+    ) -> Result<String, String> {
+        let model_path = model_path.as_ref();
+        if !model_path.exists() {
+            return Err(format!("Model path does not exist: {}", model_path.display()));
+        }
+
+        let model_id = model_id
+            .map(|s| s.to_string())
+            .unwrap_or_else(|| {
+                model_path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            });
+
+        {
+            let engines = self.engines.read().unwrap();
+            if engines.contains_key(&model_id) {
+                return Ok(model_id);
+            }
+        }
+
+        let config_json = model_path.join("config.json");
+        let model_type = if config_json.exists() {
+            std::fs::read_to_string(&config_json)
+                .ok()
+                .and_then(|s| {
+                    serde_json::from_str::<serde_json::Value>(&s)
+                        .ok()
+                        .and_then(|v| v.get("model_type").and_then(|v| v.as_str()).map(|s| s.to_string()))
+                })
+                .unwrap_or_else(|| "qwen2".to_string())
+        } else {
+            "qwen2".to_string()
+        };
+
+        let backend = detect_backend(&model_type)
+            .ok_or_else(|| format!("Unknown model type: {}", model_type))?;
+
+        let engine = LlmEngine::load(model_path, backend, &model_id)
+            .map_err(|e| format!("Failed to load model from path: {}", e))?;
+
+        let mut engines = self.engines.write().unwrap();
+        engines.insert(model_id.clone(), Arc::new(RwLock::new(engine)));
+
+        Ok(model_id)
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -80,7 +80,8 @@ impl LocalLLMClient {
     pub fn load_model(&self, model_id: &str) -> Result<(), String> {
         // Check if already loaded (quick read check first)
         {
-            let engines = self.engines.read().unwrap();
+            let engines = self.engines.read()
+                .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
             if engines.contains_key(model_id) {
                 return Ok(());
             }
@@ -88,7 +89,8 @@ impl LocalLLMClient {
 
         // Get model entry info (outside the write lock to minimize lock time)
         let model_entry = {
-            let config = self.config.read().unwrap();
+            let config = self.config.read()
+                .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
             config
                 .models
                 .iter()
@@ -106,7 +108,8 @@ impl LocalLLMClient {
         }
 
         // Double-check and insert with write lock to prevent race condition
-        let mut engines = self.engines.write().unwrap();
+        let mut engines = self.engines.write()
+            .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
         // Check again under write lock to prevent duplicate loads
         if engines.contains_key(model_id) {
             return Ok(());
@@ -128,14 +131,16 @@ impl LocalLLMClient {
         max_tokens: usize,
         temperature: f32,
     ) -> Result<ChatResult, String> {
-        let engines = self.engines.read().unwrap();
+        let engines = self.engines.read()
+            .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
         let engine_arc = engines
             .get(model_id)
             .ok_or_else(|| format!("Model '{}' is not loaded. Call load_model() first.", model_id))?
             .clone();
         drop(engines);
 
-        let mut engine = engine_arc.write().unwrap();
+        let mut engine = engine_arc.write()
+            .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
         engine.chat(messages, max_tokens, temperature)
     }
 
@@ -158,7 +163,8 @@ impl LocalLLMClient {
     }
 
     pub fn scan_models_dir(&self) -> Result<(), String> {
-        let mut config = self.config.write().unwrap();
+        let mut config = self.config.write()
+            .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
         config.scan_models_dir();
         config.save()
             .map_err(|e| format!("Failed to save config: {}", e))?;
@@ -213,7 +219,8 @@ impl LocalLLMClient {
             });
 
         {
-            let engines = self.engines.read().unwrap();
+            let engines = self.engines.read()
+                .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
             if engines.contains_key(&model_id) {
                 return Ok(model_id);
             }
@@ -239,7 +246,8 @@ impl LocalLLMClient {
         let engine = LlmEngine::load(model_path, backend, &model_id)
             .map_err(|e| format!("Failed to load model from path: {}", e))?;
 
-        let mut engines = self.engines.write().unwrap();
+        let mut engines = self.engines.write()
+            .map_err(|_| "Lock poisoned: another thread panicked while holding the lock".to_string())?;
         engines.insert(model_id.clone(), Arc::new(RwLock::new(engine)));
 
         Ok(model_id)

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -245,10 +245,19 @@ impl Clone for LocalLLMClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::thread;
 
     #[test]
     fn test_new_with_default_dir() {
         let client = LocalLLMClient::new(None);
+        assert!(client.is_ok());
+    }
+
+    #[test]
+    fn test_new_with_custom_dir() {
+        let temp_dir = std::env::temp_dir().join("test_models_mofa");
+        let client = LocalLLMClient::new(Some(temp_dir));
         assert!(client.is_ok());
     }
 
@@ -263,5 +272,158 @@ mod tests {
     fn test_is_model_loaded_false() {
         let client = LocalLLMClient::new(None).unwrap();
         assert!(!client.is_model_loaded("nonexistent-model"));
+    }
+
+    #[test]
+    fn test_get_model_info_nonexistent() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let info = client.get_model_info("nonexistent-model");
+        assert!(info.is_none());
+    }
+
+    #[test]
+    fn test_models_dir() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let dir = client.models_dir();
+        assert!(!dir.as_os_str().is_empty());
+    }
+
+    #[test]
+    fn test_loaded_models_empty() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let loaded = client.loaded_models();
+        assert_eq!(loaded.len(), 0);
+    }
+
+    #[test]
+    fn test_unload_model_not_loaded() {
+        let client = LocalLLMClient::new(None).unwrap();
+        // Should not panic
+        client.unload_model("nonexistent-model");
+    }
+
+    #[test]
+    fn test_load_model_not_found() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let result = client.load_model("nonexistent-model");
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(error_msg.contains("not found") || error_msg.contains("Model"));
+    }
+
+    #[test]
+    fn test_chat_model_not_loaded() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let messages = vec![("user".to_string(), "test".to_string())];
+        let result = client.chat("nonexistent-model", &messages, 10, 0.7);
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(error_msg.contains("not loaded") || error_msg.contains("Model"));
+    }
+
+    #[test]
+    fn test_clone() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let cloned = client.clone();
+        assert_eq!(client.list_models(), cloned.list_models());
+    }
+
+    #[test]
+    fn test_concurrent_list_models() {
+        let client = Arc::new(LocalLLMClient::new(None).unwrap());
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let client_clone = Arc::clone(&client);
+            handles.push(thread::spawn(move || {
+                client_clone.list_models()
+            }));
+        }
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All threads should get the same result
+        assert!(results.iter().all(|r| r == &results[0]));
+    }
+
+    #[test]
+    fn test_concurrent_is_model_loaded() {
+        let client = Arc::new(LocalLLMClient::new(None).unwrap());
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let client_clone = Arc::clone(&client);
+            handles.push(thread::spawn(move || {
+                client_clone.is_model_loaded("test-model")
+            }));
+        }
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All threads should get the same result
+        assert!(results.iter().all(|r| r == &results[0]));
+    }
+
+    #[test]
+    fn test_concurrent_get_model_info() {
+        let client = Arc::new(LocalLLMClient::new(None).unwrap());
+        let mut handles = vec![];
+
+        for _ in 0..10 {
+            let client_clone = Arc::clone(&client);
+            handles.push(thread::spawn(move || {
+                client_clone.get_model_info("test-model")
+            }));
+        }
+
+        let results: Vec<_> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All threads should get the same result
+        assert!(results.iter().all(|r| r == &results[0]));
+    }
+
+    #[test]
+    fn test_scan_models_dir() {
+        let client = LocalLLMClient::new(None).unwrap();
+        // Should not panic
+        client.scan_models_dir();
+    }
+
+    #[test]
+    fn test_config() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let config = client.config();
+        assert!(!config.models_dir.is_empty());
+    }
+
+    #[test]
+    fn test_default_model() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let default = client.default_model();
+        // May be None if no models available
+        if let Some(model_id) = default {
+            assert!(!model_id.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_is_model_available() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let available = client.is_model_available("nonexistent-model");
+        assert!(!available);
+    }
+
+    #[test]
+    fn test_get_model_backend_nonexistent() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let backend = client.get_model_backend("nonexistent-model");
+        assert!(backend.is_none());
+    }
+
+    #[test]
+    fn test_load_model_from_path_invalid() {
+        let client = LocalLLMClient::new(None).unwrap();
+        let invalid_path = std::path::Path::new("/nonexistent/path/to/model");
+        let result = client.load_model_from_path(invalid_path, None);
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err();
+        assert!(error_msg.contains("does not exist"));
     }
 }

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -111,3 +111,21 @@ impl LocalLLMClient {
         Ok(())
     }
 }
+    pub fn chat(
+        &self,
+        model_id: &str,
+        messages: &[(String, String)],
+        max_tokens: usize,
+        temperature: f32,
+    ) -> Result<ChatResult, String> {
+        let engines = self.engines.read().unwrap();
+        let engine_arc = engines
+            .get(model_id)
+            .ok_or_else(|| format!("Model '{}' is not loaded. Call load_model() first.", model_id))?
+            .clone();
+        drop(engines);
+
+        let mut engine = engine_arc.write().unwrap();
+        engine.chat(messages, max_tokens, temperature)
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -233,3 +233,11 @@ impl LocalLLMClient {
         Ok(model_id)
     }
 }
+impl Clone for LocalLLMClient {
+    fn clone(&self) -> Self {
+        Self {
+            config: Arc::clone(&self.config),
+            engines: Arc::clone(&self.engines),
+        }
+    }
+}

--- a/src/lib_api.rs
+++ b/src/lib_api.rs
@@ -52,3 +52,18 @@ impl LocalLLMClient {
         })
     }
 }
+    pub fn models_dir(&self) -> PathBuf {
+        let config = self.config.read().unwrap();
+        PathBuf::from(&config.models_dir)
+    }
+
+    pub fn list_models(&self) -> Vec<String> {
+        let config = self.config.read().unwrap();
+        config.models.iter().map(|m| m.id.clone()).collect()
+    }
+
+    pub fn is_model_loaded(&self, model_id: &str) -> bool {
+        let engines = self.engines.read().unwrap();
+        engines.contains_key(model_id)
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a clean, thread-safe library API to mofa-local-llm that allows the crate to be used as a dependency in other projects (e.g., MoFA) without requiring the HTTP server or GUI components.

## Changes

### Core Implementation
- New `LocalLLMClient` struct (`src/lib_api.rs`): Thread-safe client for managing and using local LLM models
  - Model loading/unloading with lifecycle management
  - Chat completion interface
  - Model discovery and registry management
  - Support for multiple models loaded simultaneously

### Exports (`src/lib.rs`)
- Export `LocalLLMClient` for easy access
- Export `ChatResult` type
- Export `ModelEntry` type for model metadata access

### Features
- Thread-safe design using `Arc<RwLock<>>`
- Multiple models can be loaded concurrently
- Lazy model loading (load on demand)
- Model discovery from `~/.mofa/models/` directory
- Automatic backend detection from model type
- Support for all LLM backends (Qwen2/3, Mistral, GLM-4, Mixtral, MiniCPM-SALA)

### Testing
- Unit tests for all core methods
- Edge case tests (error handling, invalid inputs)
- Concurrent access tests verifying thread safety
- Tests for model query methods, loading, and chat functionality

### Documentation
- Complete API documentation in `library_api.md`
- Usage examples (sync and async)
- Concurrency notes explaining per-model serialization
- Integration guide for MoFA

## API Example

```rust
use mofa_local_llm::LocalLLMClient;

let client = LocalLLMClient::new(None)?;
client.load_model("qwen2.5-0.5b-instruct")?;

let result = client.chat(
    "qwen2.5-0.5b-instruct",
    &[("user".to_string(), "Hello!".to_string())],
    128,
    0.7,
)?;
```

## Backward Compatibility

No breaking changes - All existing functionality preserved
- HTTP server (`mofa-server`) continues to work unchanged
- GUI (`mofa-gui`) continues to work unchanged
- Library API is additive only

## Related

This is PR 1 of the integration plan. Once merged, MoFA can implement `LocalLLMProvider` in PR 2.

## Commits

- add lib_api module declaration
- add local llm client struct
- add model query methods
- add load model method
- add chat method
- add helper methods
- add clone implementation
- add unit tests
- add library api documentation
- add library usage note to cargo.toml
- fix syntax errors in lib_api.rs
- add edge case tests and concurrent access tests

fixes #11 
